### PR TITLE
Guard sidebar against server-side window usage

### DIFF
--- a/components/FinanzasApp.js
+++ b/components/FinanzasApp.js
@@ -7,6 +7,7 @@ export default function FinanzasApp() {
   const [sidebarOpen, setSidebarOpen] = useState(false); // Empezar cerrado en mobile
   const [activeSection, setActiveSection] = useState('dashboard');
   const [selectedMonth, setSelectedMonth] = useState('2024-03');
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth < 1024 : false;
 
   // Datos de ejemplo
   const mockData = {
@@ -352,7 +353,7 @@ export default function FinanzasApp() {
       } bg-white shadow-lg transition-all duration-300 flex flex-col fixed lg:relative h-full z-30`}>
         {/* Header */}
         <div className="p-4 border-b border-gray-200 flex items-center justify-between">
-          {(sidebarOpen || window.innerWidth >= 1024) && (
+          {(sidebarOpen || !isMobile) && (
             <h1 className="text-xl font-bold text-gray-800">Finanzas Hogar</h1>
           )}
           <button
@@ -372,7 +373,7 @@ export default function FinanzasApp() {
                 key={item.id}
                 onClick={() => {
                   setActiveSection(item.id);
-                  if (window.innerWidth < 1024) {
+                  if (isMobile) {
                     setSidebarOpen(false);
                   }
                 }}


### PR DESCRIPTION
## Summary
- avoid accessing `window` during server rendering by adding a mobile-width check

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c47d7f101c8324bba3f77b789fe894