### PR TITLE
Adjust sidebar collapse behavior

### DIFF
--- a/components/FinanzasApp.js
+++ b/components/FinanzasApp.js
@@ -346,14 +346,18 @@ export default function FinanzasApp() {
       )}
 
       {/* Sidebar */}
-      <div className={`${
-        sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-      } lg:translate-x-0 ${
-        sidebarOpen ? 'w-64' : 'lg:w-16'
-      } bg-white shadow-lg transition-all duration-300 flex flex-col fixed lg:relative h-full z-30`}>
+      <div
+        className={`${
+          sidebarOpen ? 'translate-x-0 w-64' : '-translate-x-full w-64 lg:w-16'
+        } lg:translate-x-0 bg-white shadow-lg transition-all duration-300 flex flex-col fixed lg:relative h-full z-30 overflow-hidden`}
+      >
         {/* Header */}
-        <div className="p-4 border-b border-gray-200 flex items-center justify-between">
-          {(sidebarOpen || !isMobile) && (
+        <div
+          className={`p-4 border-b border-gray-200 flex items-center ${
+            sidebarOpen ? 'justify-between' : 'justify-center'
+          }`}
+        >
+          {(sidebarOpen || isMobile) && (
             <h1 className="text-xl font-bold text-gray-800">Finanzas Hogar</h1>
           )}
           <button
@@ -378,13 +382,15 @@ export default function FinanzasApp() {
                   }
                 }}
                 className={`w-full flex items-center px-3 py-2 rounded-lg transition-colors ${
-                  activeSection === item.id 
-                    ? 'bg-blue-100 text-blue-700' 
+                  sidebarOpen ? 'justify-start' : 'justify-center'
+                } ${
+                  activeSection === item.id
+                    ? 'bg-blue-100 text-blue-700'
                     : 'text-gray-700 hover:bg-gray-100'
                 }`}
               >
                 <Icon className="h-5 w-5 flex-shrink-0" />
-                {(sidebarOpen || !isMobile) && (
+                {(sidebarOpen || isMobile) && (
                   <span className="ml-3">{item.label}</span>
                 )}
               </button>


### PR DESCRIPTION
## Summary
- ensure the collapsed sidebar only displays icons by hiding the menu title and labels
- tighten the sidebar layout with width and alignment tweaks so content no longer overlaps the main page

## Testing
- npm run build *(fails: Next.js could not download the Inter font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c853362f648324b8eb71a7b13ad46e