### PR TITLE
Extract ingresos view into separate component

### DIFF
--- a/components/FinanzasApp.js
+++ b/components/FinanzasApp.js
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import { Menu, X, Home, TrendingUp, DollarSign, PieChart, Users, Settings, Plus, AlertTriangle, ArrowUp, ArrowDown } from 'lucide-react';
 
+import Ingresos from './ingresos/Ingresos';
+
 export default function FinanzasApp() {
   const [sidebarOpen, setSidebarOpen] = useState(false); // Empezar cerrado en mobile
   const [activeSection, setActiveSection] = useState('dashboard');
@@ -118,52 +120,6 @@ export default function FinanzasApp() {
         <h3 className="text-lg font-semibold mb-4">Evolución Mensual</h3>
         <div className="h-48 sm:h-64 bg-gray-100 rounded flex items-center justify-center">
           <p className="text-gray-500 text-center px-4">[Aquí iría el gráfico de tendencias]</p>
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderIngresos = () => (
-    <div className="space-y-6">
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">Ingresos</h1>
-        <button 
-          onClick={() => alert('Funcionalidad de agregar ingreso - En desarrollo')}
-          className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg flex items-center transition-colors"
-        >
-          <Plus className="h-4 w-4 mr-2" />
-          Agregar Ingreso
-        </button>
-      </div>
-
-      <div className="bg-white rounded-lg shadow-lg overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
-                <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Concepto</th>
-                <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Categoría</th>
-                <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Usuario</th>
-                <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Monto</th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {mockData.ingresos.map((ingreso) => (
-                <tr key={ingreso.id} className="hover:bg-gray-50">
-                  <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.fecha}</td>
-                  <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.concepto}</td>
-                  <td className="px-3 sm:px-6 py-4 whitespace-nowrap">
-                    <span className="inline-flex px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">
-                      {ingreso.categoria}
-                    </span>
-                  </td>
-                  <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.usuario}</td>
-                  <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm font-semibold text-green-600">{formatMoney(ingreso.monto)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
         </div>
       </div>
     </div>
@@ -316,7 +272,7 @@ export default function FinanzasApp() {
   const renderContent = () => {
     switch (activeSection) {
       case 'dashboard': return renderDashboard();
-      case 'ingresos': return renderIngresos();
+      case 'ingresos': return <Ingresos ingresos={mockData.ingresos} formatMoney={formatMoney} />;
       case 'gastos': return renderGastos();
       case 'inversiones': return renderInversiones();
       case 'usuarios': return (

--- a/components/ingresos/Ingresos.js
+++ b/components/ingresos/Ingresos.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Plus } from 'lucide-react';
+
+const Ingresos = ({ ingresos, formatMoney }) => (
+  <div className="space-y-6">
+    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+      <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">Ingresos</h1>
+      <button
+        onClick={() => alert('Funcionalidad de agregar ingreso - En desarrollo')}
+        className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg flex items-center transition-colors"
+      >
+        <Plus className="h-4 w-4 mr-2" />
+        Agregar Ingreso
+      </button>
+    </div>
+
+    <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Concepto</th>
+              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Categoría</th>
+              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Usuario</th>
+              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Monto</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {ingresos.map((ingreso) => (
+              <tr key={ingreso.id} className="hover:bg-gray-50">
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.fecha}</td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.concepto}</td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap">
+                  <span className="inline-flex px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">
+                    {ingreso.categoria}
+                  </span>
+                </td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.usuario}</td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm font-semibold text-green-600">{formatMoney(ingreso.monto)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+);
+
+export default Ingresos;


### PR DESCRIPTION
## Summary
- create an `Ingresos` component to encapsulate the income table markup
- pass `mockData.ingresos` and the `formatMoney` helper into the new component from `FinanzasApp`
- replace the previous `renderIngresos` function with the new component

## Testing
- not run (requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68c9602a3fbc8324861ad478af198c27