### PR TITLE
feat: persist incomes with supabase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/components/FinanzasApp.js
+++ b/components/FinanzasApp.js
@@ -17,9 +17,36 @@ export default function FinanzasApp() {
   // Datos de ejemplo
   const mockData = {
     ingresos: [
-      { id: 1, fecha: '2024-03-01', concepto: 'Sueldo Juan', categoria: 'Salario', monto: 850000, usuario: 'Juan' },
-      { id: 2, fecha: '2024-03-01', concepto: 'Sueldo María', categoria: 'Salario', monto: 720000, usuario: 'María' },
-      { id: 3, fecha: '2024-03-15', concepto: 'Freelance', categoria: 'Extra', monto: 150000, usuario: 'Juan' }
+      {
+        id: 1,
+        fecha: '2024-03-01',
+        concepto: 'Sueldo Juan',
+        usuario: 'Juan',
+        tipoMovimiento: 'Salario',
+        tipoDeCambio: 'Oficial',
+        montoARS: 850000,
+        montoUSD: 0,
+      },
+      {
+        id: 2,
+        fecha: '2024-03-01',
+        concepto: 'Sueldo María',
+        usuario: 'María',
+        tipoMovimiento: 'Salario',
+        tipoDeCambio: 'Oficial',
+        montoARS: 720000,
+        montoUSD: 0,
+      },
+      {
+        id: 3,
+        fecha: '2024-03-15',
+        concepto: 'Freelance',
+        usuario: 'Juan',
+        tipoMovimiento: 'Extra',
+        tipoDeCambio: 'MEP',
+        montoARS: 150000,
+        montoUSD: 500,
+      },
     ],
     gastos: [
       { id: 1, fecha: '2024-03-05', concepto: 'Supermercado', categoria: 'Alimentación', monto: 85000, usuario: 'María' },
@@ -44,7 +71,7 @@ export default function FinanzasApp() {
     { id: 'configuracion', icon: Settings, label: 'Configuración' }
   ];
 
-  const totalIngresos = mockData.ingresos.reduce((sum, item) => sum + item.monto, 0);
+  const totalIngresos = mockData.ingresos.reduce((sum, item) => sum + (item.montoARS ?? 0), 0);
   const totalGastos = mockData.gastos.reduce((sum, item) => sum + item.monto, 0);
   const metaAhorro = 0.20;
   const ahorroActual = totalIngresos - totalGastos;
@@ -72,7 +99,7 @@ export default function FinanzasApp() {
           formatMoney={formatMoney}
         />
       ),
-      ingresos: <Ingresos ingresos={mockData.ingresos} formatMoney={formatMoney} />,
+      ingresos: <Ingresos />,
       gastos: <Gastos gastos={mockData.gastos} formatMoney={formatMoney} />,
       inversiones: <Inversiones inversiones={mockData.inversiones} formatMoney={formatMoney} />,
       usuarios: (

--- a/components/ingresos/Ingresos.js
+++ b/components/ingresos/Ingresos.js
@@ -1,50 +1,430 @@
-import React from 'react';
-import { Plus } from 'lucide-react';
+'use client';
 
-const Ingresos = ({ ingresos, formatMoney }) => (
-  <div className="space-y-6">
-    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-      <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">Ingresos</h1>
-      <button
-        onClick={() => alert('Funcionalidad de agregar ingreso - En desarrollo')}
-        className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg flex items-center transition-colors"
-      >
-        <Plus className="h-4 w-4 mr-2" />
-        Agregar Ingreso
-      </button>
-    </div>
+import React, { useEffect, useState } from 'react';
+import { Plus, Loader2, AlertCircle } from 'lucide-react';
 
-    <div className="bg-white rounded-lg shadow-lg overflow-hidden">
-      <div className="overflow-x-auto">
-        <table className="min-w-full">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
-              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Concepto</th>
-              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Categoría</th>
-              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Usuario</th>
-              <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Monto</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {ingresos.map((ingreso) => (
-              <tr key={ingreso.id} className="hover:bg-gray-50">
-                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.fecha}</td>
-                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.concepto}</td>
-                <td className="px-3 sm:px-6 py-4 whitespace-nowrap">
-                  <span className="inline-flex px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">
-                    {ingreso.categoria}
-                  </span>
-                </td>
-                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">{ingreso.usuario}</td>
-                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm font-semibold text-green-600">{formatMoney(ingreso.monto)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+import { createIngreso, fetchIngresos } from '../../lib/supabaseClient';
+
+const createInitialFormState = () => ({
+  fecha: new Date().toISOString().split('T')[0],
+  concepto: '',
+  usuario: '',
+  tipoMovimiento: '',
+  tipoDeCambio: '',
+  montoARS: '',
+  montoUSD: '',
+});
+
+const parseAmount = (value) => {
+  if (value === '' || value === null || value === undefined) {
+    return null;
+  }
+
+  const amount = Number(value);
+  return Number.isNaN(amount) ? null : amount;
+};
+
+const formatCurrency = (value, currency) => {
+  if (value === null || value === undefined || value === '') {
+    return '—';
+  }
+
+  const amount = Number(value);
+
+  if (!Number.isFinite(amount)) {
+    return '—';
+  }
+
+  return new Intl.NumberFormat(currency === 'ARS' ? 'es-AR' : 'en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+};
+
+const formatDate = (value) => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString('es-AR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const buildFallbackId = (record) => {
+  const globalCrypto = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return globalCrypto.randomUUID();
+  }
+
+  const base = [record.fecha, record.concepto, record.usuario].filter(Boolean).join('-');
+  return `${base}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const normalizeIngreso = (record) => ({
+  id: record.id ?? record.uuid ?? buildFallbackId(record),
+  fecha: record.fecha ?? '',
+  concepto: record.concepto ?? '',
+  usuario: record.usuario ?? '',
+  tipoMovimiento: record.tipoMovimiento ?? record.tipo_movimiento ?? '',
+  tipoDeCambio:
+    record.tipoDeCambio ?? record.tipo_de_cambio ?? record.tipo_cambio ?? record.tipoCambio ?? '',
+  montoARS: record.montoARS ?? record.monto_ars ?? null,
+  montoUSD: record.montoUSD ?? record.monto_usd ?? null,
+});
+
+const sortByFechaDesc = (items) =>
+  [...items].sort((a, b) => {
+    const dateA = new Date(a.fecha).getTime();
+    const dateB = new Date(b.fecha).getTime();
+
+    if (Number.isNaN(dateA) && Number.isNaN(dateB)) {
+      return 0;
+    }
+
+    if (Number.isNaN(dateA)) {
+      return 1;
+    }
+
+    if (Number.isNaN(dateB)) {
+      return -1;
+    }
+
+    return dateB - dateA;
+  });
+
+const Ingresos = () => {
+  const [ingresos, setIngresos] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [formError, setFormError] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formData, setFormData] = useState(createInitialFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const loadIngresos = async () => {
+      setLoading(true);
+      setLoadError(null);
+
+      try {
+        const data = await fetchIngresos();
+        const normalized = Array.isArray(data) ? data.map(normalizeIngreso) : [];
+        setIngresos(sortByFechaDesc(normalized));
+      } catch (error) {
+        console.error('Error al obtener los ingresos', error);
+        setLoadError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadIngresos();
+  }, []);
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({ ...previous, [name]: value }));
+  };
+
+  const resetForm = () => {
+    setFormData(createInitialFormState());
+  };
+
+  const handleCancel = () => {
+    resetForm();
+    setFormError(null);
+    setShowForm(false);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setFormError(null);
+    setIsSubmitting(true);
+
+    try {
+      const payload = {
+        fecha: formData.fecha,
+        concepto: formData.concepto.trim(),
+        usuario: formData.usuario.trim(),
+        tipo_movimiento: formData.tipoMovimiento.trim(),
+        tipo_de_cambio: formData.tipoDeCambio.trim(),
+        monto_ars: parseAmount(formData.montoARS),
+        monto_usd: parseAmount(formData.montoUSD),
+      };
+
+      const newIngreso = await createIngreso(payload);
+      const normalizedIngreso = normalizeIngreso(newIngreso);
+
+      setIngresos((previous) => sortByFechaDesc([normalizedIngreso, ...previous]));
+      resetForm();
+      setShowForm(false);
+    } catch (error) {
+      console.error('Error al crear un ingreso', error);
+      setFormError(error.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">Ingresos</h1>
+        <button
+          type="button"
+          onClick={() => {
+            setShowForm(true);
+            setFormError(null);
+          }}
+          className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg flex items-center transition-colors"
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Agregar ingreso
+        </button>
+      </div>
+
+      {loadError && (
+        <div className="bg-red-50 border border-red-100 text-red-700 px-4 py-3 rounded-lg flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="font-semibold">No pudimos cargar los ingresos</p>
+            <p className="text-sm">{loadError}</p>
+          </div>
+        </div>
+      )}
+
+      {formError && (
+        <div className="bg-red-50 border border-red-100 text-red-700 px-4 py-3 rounded-lg flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="font-semibold">No pudimos guardar el ingreso</p>
+            <p className="text-sm">{formError}</p>
+          </div>
+        </div>
+      )}
+
+      {showForm && (
+        <div className="bg-white rounded-lg shadow-lg border border-gray-200">
+          <form onSubmit={handleSubmit} className="p-6 space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="fecha" className="block text-sm font-medium text-gray-700 mb-1">
+                  Fecha
+                </label>
+                <input
+                  id="fecha"
+                  name="fecha"
+                  type="date"
+                  value={formData.fecha}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="concepto" className="block text-sm font-medium text-gray-700 mb-1">
+                  Concepto
+                </label>
+                <input
+                  id="concepto"
+                  name="concepto"
+                  type="text"
+                  value={formData.concepto}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="usuario" className="block text-sm font-medium text-gray-700 mb-1">
+                  Usuario
+                </label>
+                <input
+                  id="usuario"
+                  name="usuario"
+                  type="text"
+                  value={formData.usuario}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="tipoMovimiento" className="block text-sm font-medium text-gray-700 mb-1">
+                  Tipo de movimiento
+                </label>
+                <input
+                  id="tipoMovimiento"
+                  name="tipoMovimiento"
+                  type="text"
+                  value={formData.tipoMovimiento}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                  placeholder="Salario, Extra, Inversión, etc."
+                />
+              </div>
+
+              <div>
+                <label htmlFor="tipoDeCambio" className="block text-sm font-medium text-gray-700 mb-1">
+                  Tipo de cambio
+                </label>
+                <input
+                  id="tipoDeCambio"
+                  name="tipoDeCambio"
+                  type="text"
+                  value={formData.tipoDeCambio}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                  placeholder="Oficial, MEP, Blue, etc."
+                />
+              </div>
+
+              <div>
+                <label htmlFor="montoARS" className="block text-sm font-medium text-gray-700 mb-1">
+                  Monto (ARS)
+                </label>
+                <input
+                  id="montoARS"
+                  name="montoARS"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formData.montoARS}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="montoUSD" className="block text-sm font-medium text-gray-700 mb-1">
+                  Monto (USD)
+                </label>
+                <input
+                  id="montoUSD"
+                  name="montoUSD"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formData.montoUSD}
+                  onChange={handleInputChange}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                  placeholder="Opcional"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="px-4 py-2 rounded-lg bg-green-500 text-white hover:bg-green-600 transition-colors disabled:opacity-60 disabled:cursor-not-allowed flex items-center"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" /> Guardando
+                  </>
+                ) : (
+                  'Guardar ingreso'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+        <div className="overflow-x-auto">
+          {loading ? (
+            <div className="p-6 text-center text-gray-500 text-sm">Cargando ingresos...</div>
+          ) : ingresos.length === 0 ? (
+            <div className="p-6 text-center text-gray-500 text-sm">
+              {loadError ? 'No pudimos cargar los ingresos.' : 'Todavía no registraste ingresos.'}
+            </div>
+          ) : (
+            <table className="min-w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Fecha
+                  </th>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Concepto
+                  </th>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Usuario
+                  </th>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Tipo movimiento
+                  </th>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Tipo de cambio
+                  </th>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Monto ARS
+                  </th>
+                  <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Monto USD
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {ingresos.map((ingreso) => (
+                  <tr key={ingreso.id} className="hover:bg-gray-50">
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {formatDate(ingreso.fecha)}
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {ingreso.concepto || '—'}
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {ingreso.usuario || '—'}
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {ingreso.tipoMovimiento || '—'}
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {ingreso.tipoDeCambio || '—'}
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm font-semibold text-green-600">
+                      {formatCurrency(ingreso.montoARS, 'ARS')}
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm font-semibold text-blue-600">
+                      {formatCurrency(ingreso.montoUSD, 'USD')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Ingresos;

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,0 +1,61 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+const missingEnvMessage =
+  'Las variables NEXT_PUBLIC_SUPABASE_URL y NEXT_PUBLIC_SUPABASE_ANON_KEY no están configuradas. ' +
+  'Agregalas en tu entorno para habilitar la conexión con Supabase.';
+
+function ensureEnv() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error(missingEnvMessage);
+  }
+}
+
+function buildHeaders(additionalHeaders = {}) {
+  ensureEnv();
+
+  return {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...additionalHeaders,
+  };
+}
+
+async function handleResponse(response) {
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || 'Error al comunicarse con Supabase.');
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+export async function fetchIngresos() {
+  const url = `${SUPABASE_URL}/rest/v1/ingresos?select=*&order=fecha.desc`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: buildHeaders(),
+    cache: 'no-store',
+  });
+
+  return handleResponse(response);
+}
+
+export async function createIngreso(ingreso) {
+  const url = `${SUPABASE_URL}/rest/v1/ingresos`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: buildHeaders({ Prefer: 'return=representation' }),
+    body: JSON.stringify([ingreso]),
+    cache: 'no-store',
+  });
+
+  const data = await handleResponse(response);
+  return Array.isArray(data) ? data[0] : data;
+}

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,30 @@ La aplicación estará disponible en `http://localhost:3000`
 - `npm run start` - Servidor de producción
 - `npm run lint` - Linter de código
 
+## 🔐 Configuración de Supabase
+
+Para que los ingresos se sincronicen con Supabase necesitás configurar las siguientes variables de entorno (por ejemplo en un archivo `.env.local`):
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL="https://<tu-proyecto>.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="<tu_anon_key>"
+```
+
+También asegurate de crear en Supabase una tabla llamada `ingresos` con las columnas:
+
+| Columna          | Tipo sugerido | Descripción                          |
+| ---------------- | ------------- | ------------------------------------ |
+| `id`             | uuid (PK)     | Identificador único generado por DB |
+| `fecha`          | date          | Fecha del movimiento                 |
+| `concepto`       | text          | Descripción del ingreso              |
+| `usuario`        | text          | Miembro de la familia                |
+| `tipo_movimiento` | text          | Categoría o tipo de ingreso          |
+| `tipo_de_cambio`  | text          | Referencia del tipo de cambio        |
+| `monto_ars`      | numeric       | Importe en pesos argentinos          |
+| `monto_usd`      | numeric       | Importe en dólares (opcional)        |
+
+La aplicación utiliza el API REST de Supabase, por lo que los permisos de la política de seguridad (RLS) deben permitir leer e insertar registros con la clave anónima.
+
 ## 🚀 Deploy en Vercel
 
 Este proyecto está configurado para deploy automático en Vercel:


### PR DESCRIPTION
## Summary
- add a Supabase REST helper to fetch and guardar ingresos
- rebuild the ingresos view with the nueva grilla, formulario completo y manejo de errores
- actualizar los datos de ejemplo y documentación para reflejar la estructura de ingresos y configurar ESLint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c97d65ce6883249c228ac0973775f3