### PR TITLE
Add gastos helpers and document Supabase requirements

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -36,8 +36,15 @@ async function handleResponse(response) {
   return response.json();
 }
 
-export async function fetchIngresos() {
-  const url = `${SUPABASE_URL}/rest/v1/ingresos?select=*&order=fecha.desc`;
+function buildTableUrl(tableName, query = '') {
+  ensureEnv();
+
+  const baseUrl = `${SUPABASE_URL}/rest/v1/${tableName}`;
+  return query ? `${baseUrl}${query}` : baseUrl;
+}
+
+async function fetchTableRows(tableName) {
+  const url = buildTableUrl(tableName, '?select=*&order=fecha.desc');
   const response = await fetch(url, {
     method: 'GET',
     headers: buildHeaders(),
@@ -47,12 +54,12 @@ export async function fetchIngresos() {
   return handleResponse(response);
 }
 
-export async function createIngreso(ingreso) {
-  const url = `${SUPABASE_URL}/rest/v1/ingresos`;
+async function createTableRow(tableName, record) {
+  const url = buildTableUrl(tableName);
   const response = await fetch(url, {
     method: 'POST',
     headers: buildHeaders({ Prefer: 'return=representation' }),
-    body: JSON.stringify([ingreso]),
+    body: JSON.stringify([record]),
     cache: 'no-store',
   });
 
@@ -60,26 +67,10 @@ export async function createIngreso(ingreso) {
   return Array.isArray(data) ? data[0] : data;
 }
 
-export async function fetchGastos() {
-  const url = `${SUPABASE_URL}/rest/v1/gastos?select=*&order=fecha.desc`;
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: buildHeaders(),
-    cache: 'no-store',
-  });
+export const fetchIngresos = () => fetchTableRows('ingresos');
 
-  return handleResponse(response);
-}
+export const createIngreso = (ingreso) => createTableRow('ingresos', ingreso);
 
-export async function createGasto(gasto) {
-  const url = `${SUPABASE_URL}/rest/v1/gastos`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: buildHeaders({ Prefer: 'return=representation' }),
-    body: JSON.stringify([gasto]),
-    cache: 'no-store',
-  });
+export const fetchGastos = () => fetchTableRows('gastos');
 
-  const data = await handleResponse(response);
-  return Array.isArray(data) ? data[0] : data;
-}
+export const createGasto = (gasto) => createTableRow('gastos', gasto);

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,8 @@ También asegurate de crear en Supabase una tabla llamada `ingresos` con las col
 | `monto_ars`      | numeric       | Importe en pesos argentinos          |
 | `monto_usd`      | numeric       | Importe en dólares (opcional)        |
 
+Para la sección de gastos, creá una tabla `gastos` con la misma estructura de columnas (incluyendo `tipo_movimiento`, `tipo_de_cambio`, `monto_ars` y `monto_usd`) para que la aplicación pueda listar y registrar egresos.
+
 La aplicación utiliza el API REST de Supabase, por lo que los permisos de la política de seguridad (RLS) deben permitir leer e insertar registros con la clave anónima.
 
 ## 🚀 Deploy en Vercel


### PR DESCRIPTION
## Summary
- add reusable helper functions to call Supabase REST endpoints
- expose gastos fetch/create helpers mirroring the ingresos API
- document the requirement for a `gastos` table in Supabase

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9c202cec083249db881a079cb5416