### PR TITLE
Handle ahorro sync without relying on Supabase upsert conflicts

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -92,7 +92,51 @@ export const fetchGastos = () => fetchTableRows('gastos');
 
 export const fetchAhorros = () => fetchTableRows('ahorros', 'periodo');
 
-export const upsertAhorro = (ahorro) => upsertTableRow('ahorros', ahorro, 'periodo');
+async function fetchAhorroByPeriod(periodo) {
+  const periodQuery = `?select=*&periodo=eq.${encodeURIComponent(periodo)}&limit=1`;
+  const url = buildTableUrl('ahorros', periodQuery);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: buildHeaders(),
+    cache: 'no-store',
+  });
+
+  const data = await handleResponse(response);
+  return Array.isArray(data) && data.length > 0 ? data[0] : null;
+}
+
+async function updateAhorro(periodo, fields) {
+  const updateQuery = `?periodo=eq.${encodeURIComponent(periodo)}`;
+  const url = buildTableUrl('ahorros', updateQuery);
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: buildHeaders({ Prefer: 'return=representation' }),
+    body: JSON.stringify(fields),
+    cache: 'no-store',
+  });
+
+  const data = await handleResponse(response);
+  return Array.isArray(data) ? data[0] : data;
+}
+
+export const upsertAhorro = async (ahorro) => {
+  const normalizedPeriod = normalizePeriod(ahorro?.periodo);
+
+  if (!normalizedPeriod) {
+    throw new Error('El periodo del ahorro no es válido.');
+  }
+
+  const existingAhorro = await fetchAhorroByPeriod(normalizedPeriod);
+
+  if (existingAhorro) {
+    return updateAhorro(normalizedPeriod, { monto: ahorro?.monto });
+  }
+
+  return createTableRow('ahorros', {
+    ...ahorro,
+    periodo: normalizedPeriod,
+  });
+};
 
 export async function syncAhorroForPeriod(period) {
   const normalizedPeriod = normalizePeriod(period);
@@ -104,7 +148,7 @@ export async function syncAhorroForPeriod(period) {
   const [ingresos, gastos] = await Promise.all([fetchIngresos(), fetchGastos()]);
   const { ahorroDelMes } = calculateMonthlyTotals(ingresos ?? [], gastos ?? [], normalizedPeriod);
 
-  await upsertAhorro({
+  return upsertAhorro({
     periodo: normalizedPeriod,
     monto: ahorroDelMes,
   });


### PR DESCRIPTION
## Summary
- replace the ahorro upsert helper to perform an explicit GET followed by a PATCH or POST
- ensure `syncAhorroForPeriod` returns the persisted ahorro record for consumers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb0ea97c58832483856a07ff37451c