### PR TITLE
Fix local date rendering for ingresos y gastos

### DIFF
--- a/components/ingresos/Ingresos.js
+++ b/components/ingresos/Ingresos.js
@@ -43,15 +43,37 @@ const formatCurrency = (value, currency) => {
   }).format(amount);
 };
 
-const formatDate = (value) => {
+const parseDateValue = (value) => {
   if (!value) {
-    return '—';
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === 'string') {
+    const parts = value.split('-').map((part) => Number.parseInt(part, 10));
+
+    if (parts.length === 3 && parts.every((part) => Number.isInteger(part))) {
+      const [year, month, day] = parts;
+      const date = new Date(year, month - 1, day);
+
+      if (!Number.isNaN(date.getTime())) {
+        return date;
+      }
+    }
   }
 
   const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
 
-  if (Number.isNaN(date.getTime())) {
-    return value;
+const formatDate = (value) => {
+  const date = parseDateValue(value);
+
+  if (!date) {
+    return typeof value === 'string' && value.trim() ? value : '—';
   }
 
   return date.toLocaleDateString('es-AR', {
@@ -86,22 +108,22 @@ const normalizeIngreso = (record) => ({
 
 const sortByFechaDesc = (items) =>
   [...items].sort((a, b) => {
-    const dateA = new Date(a.fecha).getTime();
-    const dateB = new Date(b.fecha).getTime();
+    const dateA = parseDateValue(a.fecha);
+    const dateB = parseDateValue(b.fecha);
 
-    if (Number.isNaN(dateA) && Number.isNaN(dateB)) {
+    if (!dateA && !dateB) {
       return 0;
     }
 
-    if (Number.isNaN(dateA)) {
+    if (!dateA) {
       return 1;
     }
 
-    if (Number.isNaN(dateB)) {
+    if (!dateB) {
       return -1;
     }
 
-    return dateB - dateA;
+    return dateB.getTime() - dateA.getTime();
   });
 
 const Ingresos = ({ onDataChanged }) => {


### PR DESCRIPTION
## Summary
- parse stored date strings into local Date objects before formatting in ingresos and gastos
- reuse the shared parsing logic for sorting to keep listings ordered correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb115c55a08324b7aecaa7114c1689