### PR TITLE
Fix dashboard expense total to sum ARS only

### DIFF
--- a/lib/financeUtils.js
+++ b/lib/financeUtils.js
@@ -111,23 +111,7 @@ export const calculateIngresoARS = (record) => {
 
 export const calculateGastoARS = (record) => {
   const montoARS = getNumericValue(record?.monto_ars ?? record?.montoARS);
-  const montoUSD = getNumericValue(record?.monto_usd ?? record?.montoUSD);
-
-  let total = 0;
-
-  if (montoARS !== null) {
-    total += montoARS;
-  }
-
-  if (montoUSD !== null) {
-    const tipoCambio = getExchangeRateValue(record?.tipo_de_cambio ?? record?.tipoDeCambio);
-
-    if (tipoCambio !== null) {
-      total += montoUSD * tipoCambio;
-    }
-  }
-
-  return total;
+  return montoARS !== null ? montoARS : 0;
 };
 
 export const calculateMonthlyTotals = (ingresos = [], gastos = [], period) => {


### PR DESCRIPTION
## Summary
- ensure the gasto total calculation used by the dashboard only sums the ARS column values
- prevent USD amounts from being converted and double-counted in the monthly totals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb188bb2e083249cb846aceef16230