### PR TITLE
Add inline editing for ingresos and gastos records

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -70,6 +70,24 @@ async function createTableRow(tableName, record) {
   return Array.isArray(data) ? data[0] : data;
 }
 
+async function updateTableRow(tableName, fieldName, value, fields) {
+  if (!fieldName || value === null || value === undefined || value === '') {
+    throw new Error('El identificador del registro no es válido.');
+  }
+
+  const updateQuery = `?${encodeURIComponent(fieldName)}=eq.${encodeURIComponent(value)}`;
+  const url = buildTableUrl(tableName, updateQuery);
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: buildHeaders({ Prefer: 'return=representation' }),
+    body: JSON.stringify(fields),
+    cache: 'no-store',
+  });
+
+  const data = await handleResponse(response);
+  return Array.isArray(data) ? data[0] : data;
+}
+
 async function upsertTableRow(tableName, record, conflictTarget) {
   const conflictQuery = conflictTarget ? `?on_conflict=${encodeURIComponent(conflictTarget)}` : '';
   const url = buildTableUrl(tableName, conflictQuery);
@@ -154,6 +172,25 @@ export async function syncAhorroForPeriod(period) {
   });
 }
 
+const getRecordPeriod = (record) => normalizePeriod(record?.fecha ?? record?.periodo ?? record?.mes);
+
+const syncAhorroAfterUpdate = async (updatedRecord, previousRecord) => {
+  const newPeriod = getRecordPeriod(updatedRecord) ?? getRecordPeriod(previousRecord);
+  const previousPeriod = getRecordPeriod(previousRecord);
+
+  const periodsToSync = new Set();
+
+  if (newPeriod) {
+    periodsToSync.add(newPeriod);
+  }
+
+  if (previousPeriod && previousPeriod !== newPeriod) {
+    periodsToSync.add(previousPeriod);
+  }
+
+  await Promise.all(Array.from(periodsToSync).map((period) => syncAhorroForPeriod(period)));
+};
+
 async function syncAhorroForRecord(record, fallbackRecord) {
   const period = normalizePeriod(
     record?.fecha ?? record?.periodo ?? fallbackRecord?.fecha ?? fallbackRecord?.periodo,
@@ -184,4 +221,30 @@ export const createGasto = async (gasto) => {
   const newGasto = await createTableRow('gastos', gasto);
   await syncAhorroForRecord(newGasto, gasto);
   return newGasto;
+};
+
+const resolveUpdateIdentifier = (record) => {
+  const field = record?.databaseIdField ?? (record?.id !== undefined ? 'id' : null);
+  const value =
+    record?.databaseId ?? (field === 'id' ? record?.id ?? null : null);
+
+  if (!field || value === null || value === undefined || value === '') {
+    throw new Error('No se puede actualizar el registro porque falta su identificador.');
+  }
+
+  return { field, value };
+};
+
+export const updateIngreso = async (previousRecord, fields) => {
+  const { field, value } = resolveUpdateIdentifier(previousRecord);
+  const updatedIngreso = await updateTableRow('ingresos', field, value, fields);
+  await syncAhorroAfterUpdate(updatedIngreso, previousRecord);
+  return updatedIngreso;
+};
+
+export const updateGasto = async (previousRecord, fields) => {
+  const { field, value } = resolveUpdateIdentifier(previousRecord);
+  const updatedGasto = await updateTableRow('gastos', field, value, fields);
+  await syncAhorroAfterUpdate(updatedGasto, previousRecord);
+  return updatedGasto;
 };


### PR DESCRIPTION
## Summary
- add pencil action buttons that let users edit fecha y montos directamente desde las tablas de Ingresos y Gastos
- guardar los cambios con botones de confirmar/cancelar y actualizar las listas ordenadas al instante
- incorporar funciones de actualización en Supabase con recálculo del ahorro mensual para los periodos afectados

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb242591908324b1682c3ba0d060f3