### PR TITLE
Handle missing Supabase update identifiers gracefully

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -224,20 +224,41 @@ export const createGasto = async (gasto) => {
 };
 
 const resolveUpdateIdentifier = (record) => {
-  const field = record?.databaseIdField ?? (record?.id !== undefined ? 'id' : null);
-  const value =
-    record?.databaseId ?? (field === 'id' ? record?.id ?? null : null);
-
-  if (!field || value === null || value === undefined || value === '') {
+  if (!record || typeof record !== 'object') {
     throw new Error('No se puede actualizar el registro porque falta su identificador.');
   }
 
-  return { field, value };
+  const field = record.databaseIdField;
+  const value = record.databaseId;
+
+  if (
+    field &&
+    value !== null &&
+    value !== undefined &&
+    value !== ''
+  ) {
+    return { field, value };
+  }
+
+  if (field === undefined) {
+    if (record.id !== null && record.id !== undefined && record.id !== '') {
+      return { field: 'id', value: record.id };
+    }
+
+    if (record.uuid !== null && record.uuid !== undefined && record.uuid !== '') {
+      return { field: 'uuid', value: record.uuid };
+    }
+  }
+
+  throw new Error('No se puede actualizar el registro porque falta su identificador.');
 };
 
 export const updateIngreso = async (previousRecord, fields) => {
   const { field, value } = resolveUpdateIdentifier(previousRecord);
   const updatedIngreso = await updateTableRow('ingresos', field, value, fields);
+  if (!updatedIngreso) {
+    throw new Error('No encontramos el ingreso que querés actualizar. Probá recargar la página.');
+  }
   await syncAhorroAfterUpdate(updatedIngreso, previousRecord);
   return updatedIngreso;
 };
@@ -245,6 +266,9 @@ export const updateIngreso = async (previousRecord, fields) => {
 export const updateGasto = async (previousRecord, fields) => {
   const { field, value } = resolveUpdateIdentifier(previousRecord);
   const updatedGasto = await updateTableRow('gastos', field, value, fields);
+  if (!updatedGasto) {
+    throw new Error('No encontramos el gasto que querés actualizar. Probá recargar la página.');
+  }
   await syncAhorroAfterUpdate(updatedGasto, previousRecord);
   return updatedGasto;
 };


### PR DESCRIPTION
## Summary
- guard the Supabase update identifier helper so it only uses valid metadata
- surface clear errors when ingresos/gastos updates do not return any record

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc498c4644832490f4e47819c37571