### PR TITLE
Improve Supabase update identifier handling

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -223,52 +223,106 @@ export const createGasto = async (gasto) => {
   return newGasto;
 };
 
-const resolveUpdateIdentifier = (record) => {
+const buildIdentifierCandidate = (field, value) => {
+  if (!field) {
+    return null;
+  }
+
+  const normalizedField = String(field).trim();
+
+  if (!normalizedField) {
+    return null;
+  }
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalizedValue = typeof value === 'string' ? value.trim() : value;
+
+  if (normalizedValue === '') {
+    return null;
+  }
+
+  return { field: normalizedField, value: normalizedValue };
+};
+
+const resolveUpdateIdentifiers = (record) => {
   if (!record || typeof record !== 'object') {
     throw new Error('No se puede actualizar el registro porque falta su identificador.');
   }
 
-  const field = record.databaseIdField;
-  const value = record.databaseId;
+  const candidates = [];
+  const seen = new Set();
 
-  if (
-    field &&
-    value !== null &&
-    value !== undefined &&
-    value !== ''
-  ) {
-    return { field, value };
-  }
+  const pushCandidate = (field, value) => {
+    const candidate = buildIdentifierCandidate(field, value);
 
-  if (field === undefined) {
-    if (record.id !== null && record.id !== undefined && record.id !== '') {
-      return { field: 'id', value: record.id };
+    if (!candidate) {
+      return;
     }
 
-    if (record.uuid !== null && record.uuid !== undefined && record.uuid !== '') {
-      return { field: 'uuid', value: record.uuid };
+    const key = `${candidate.field}:${String(candidate.value)}`;
+
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    candidates.push(candidate);
+  };
+
+  pushCandidate(record.databaseIdField, record.databaseId);
+  pushCandidate('id', record.id ?? record.Id ?? record.ID ?? record.ingreso_id ?? record.gasto_id);
+  pushCandidate('uuid', record.uuid ?? record.UUID ?? record.ingreso_uuid ?? record.gasto_uuid);
+
+  if (candidates.length === 0) {
+    throw new Error('No se puede actualizar el registro porque falta su identificador.');
+  }
+
+  return candidates;
+};
+
+const updateRecordWithIdentifiers = async (tableName, identifiers, fields) => {
+  for (const { field, value } of identifiers) {
+    try {
+      const updatedRecord = await updateTableRow(tableName, field, value, fields);
+
+      if (updatedRecord) {
+        return updatedRecord;
+      }
+    } catch (error) {
+      if (error?.message === 'El identificador del registro no es válido.') {
+        continue;
+      }
+
+      throw error;
     }
   }
 
-  throw new Error('No se puede actualizar el registro porque falta su identificador.');
+  return null;
 };
 
 export const updateIngreso = async (previousRecord, fields) => {
-  const { field, value } = resolveUpdateIdentifier(previousRecord);
-  const updatedIngreso = await updateTableRow('ingresos', field, value, fields);
+  const identifiers = resolveUpdateIdentifiers(previousRecord);
+  const updatedIngreso = await updateRecordWithIdentifiers('ingresos', identifiers, fields);
+
   if (!updatedIngreso) {
     throw new Error('No encontramos el ingreso que querés actualizar. Probá recargar la página.');
   }
+
   await syncAhorroAfterUpdate(updatedIngreso, previousRecord);
   return updatedIngreso;
 };
 
 export const updateGasto = async (previousRecord, fields) => {
-  const { field, value } = resolveUpdateIdentifier(previousRecord);
-  const updatedGasto = await updateTableRow('gastos', field, value, fields);
+  const identifiers = resolveUpdateIdentifiers(previousRecord);
+  const updatedGasto = await updateRecordWithIdentifiers('gastos', identifiers, fields);
+
   if (!updatedGasto) {
     throw new Error('No encontramos el gasto que querés actualizar. Probá recargar la página.');
   }
+
   await syncAhorroAfterUpdate(updatedGasto, previousRecord);
   return updatedGasto;
 };


### PR DESCRIPTION
## Summary
- expand the Supabase update identifier resolution to consider multiple possible id fields
- retry record updates with each candidate identifier before surfacing an error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4dba53908324902b3103a7db032f