### PR TITLE
Add delete actions and expand editing for incomes and expenses

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -88,6 +88,32 @@ async function updateTableRow(tableName, fieldName, value, fields) {
   return Array.isArray(data) ? data[0] : data;
 }
 
+async function deleteTableRow(tableName, fieldName, value) {
+  if (!fieldName || value === null || value === undefined || value === '') {
+    throw new Error('El identificador del registro no es válido.');
+  }
+
+  const deleteQuery = `?${encodeURIComponent(fieldName)}=eq.${encodeURIComponent(value)}`;
+  const url = buildTableUrl(tableName, deleteQuery);
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: buildHeaders({ Prefer: 'return=representation' }),
+    cache: 'no-store',
+  });
+
+  const data = await handleResponse(response);
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return null;
+    }
+
+    return data[0];
+  }
+
+  return data;
+}
+
 async function upsertTableRow(tableName, record, conflictTarget) {
   const conflictQuery = conflictTarget ? `?on_conflict=${encodeURIComponent(conflictTarget)}` : '';
   const url = buildTableUrl(tableName, conflictQuery);
@@ -303,6 +329,26 @@ const updateRecordWithIdentifiers = async (tableName, identifiers, fields) => {
   return null;
 };
 
+const deleteRecordWithIdentifiers = async (tableName, identifiers) => {
+  for (const { field, value } of identifiers) {
+    try {
+      const deletedRecord = await deleteTableRow(tableName, field, value);
+
+      if (deletedRecord) {
+        return deletedRecord;
+      }
+    } catch (error) {
+      if (error?.message === 'El identificador del registro no es válido.') {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return null;
+};
+
 export const updateIngreso = async (previousRecord, fields) => {
   const identifiers = resolveUpdateIdentifiers(previousRecord);
   const updatedIngreso = await updateRecordWithIdentifiers('ingresos', identifiers, fields);
@@ -325,4 +371,28 @@ export const updateGasto = async (previousRecord, fields) => {
 
   await syncAhorroAfterUpdate(updatedGasto, previousRecord);
   return updatedGasto;
+};
+
+export const deleteIngreso = async (previousRecord) => {
+  const identifiers = resolveUpdateIdentifiers(previousRecord);
+  const deletedIngreso = await deleteRecordWithIdentifiers('ingresos', identifiers);
+
+  if (!deletedIngreso) {
+    throw new Error('No encontramos el ingreso que querés borrar. Probá recargar la página.');
+  }
+
+  await syncAhorroForRecord(deletedIngreso, previousRecord);
+  return deletedIngreso;
+};
+
+export const deleteGasto = async (previousRecord) => {
+  const identifiers = resolveUpdateIdentifiers(previousRecord);
+  const deletedGasto = await deleteRecordWithIdentifiers('gastos', identifiers);
+
+  if (!deletedGasto) {
+    throw new Error('No encontramos el gasto que querés borrar. Probá recargar la página.');
+  }
+
+  await syncAhorroForRecord(deletedGasto, previousRecord);
+  return deletedGasto;
 };


### PR DESCRIPTION
## Summary
- allow editing the concepto and tipo de movimiento fields in both income and expense tables
- add delete buttons with confirmation prompts to remove individual income and expense records
- extend the Supabase client with reusable delete helpers for syncing ahorro after removing records

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd56f96ed88324b457398ebe83d722