### PR TITLE
Fix gastos breakdown bar heights

### DIFF
--- a/components/dashboard/GastosBreakdownChart.js
+++ b/components/dashboard/GastosBreakdownChart.js
@@ -234,9 +234,9 @@ export default function GastosBreakdownChart({
                   .filter(({ value }) => value > 0);
 
                 return (
-                  <div key={month.period} className="min-w-[4.5rem] flex-1">
-                    <div className="flex flex-col items-center gap-2">
-                      <div className="w-full flex-1 flex items-end">
+                  <div key={month.period} className="min-w-[4.5rem] flex-1 h-full">
+                    <div className="flex h-full flex-col items-center gap-2">
+                      <div className="w-full flex-1 flex items-end h-full">
                         <div className="w-full h-full flex items-end gap-2 rounded-lg bg-gray-50 px-2 pt-2">
                           {segments.map(({ category, value }) => {
                             const heightPercent = maxValue > 0 ? (value / maxValue) * 100 : 0;


### PR DESCRIPTION
## Summary
- ensure each gasto breakdown column and its bar container stretch to the full chart height so bar percentages reflect their values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d19c9379248324a1a16c0cd284e809